### PR TITLE
Don't export Mod Menu dependency to API consumers

### DIFF
--- a/kuma-api/fabric/dependencies.gradle
+++ b/kuma-api/fabric/dependencies.gradle
@@ -13,7 +13,7 @@ dependencies {
         modRuntimeOnly "mezz.jei:jei-$jei_minecraft_version-fabric:$jei_version"
     }
 
-    modImplementation "com.terraformersmc:modmenu:$modmenu_version"
+    modRuntimeOnly "com.terraformersmc:modmenu:$modmenu_version"
 
     modCompileOnly "me.shedaniel.cloth:cloth-config-fabric:11.0.99"
     modCompileOnly("de.siphalor:amecsapi-1.20:1.5.2+mc1.20-pre1")

--- a/kuma/fabric/dependencies.gradle
+++ b/kuma/fabric/dependencies.gradle
@@ -13,7 +13,7 @@ dependencies {
         modRuntimeOnly "mezz.jei:jei-$jei_minecraft_version-fabric:$jei_version"
     }
 
-    modImplementation "com.terraformersmc:modmenu:$modmenu_version"
+    modRuntimeOnly "com.terraformersmc:modmenu:$modmenu_version"
 
     modCompileOnly "me.shedaniel.cloth:cloth-config-fabric:11.0.99"
     modCompileOnly("de.siphalor:amecsapi-1.20:1.5.2+mc1.20-pre1")


### PR DESCRIPTION
Tiny thing I noticed when trying this out - consumers of the library currently pull Mod Menu by default, but given the README doesn't document adding the Terraformers repository, it seemed unintentional. :slightly_smiling_face: 
