### PR TITLE
refactor: Change KeyConflictContext from enum to extensible class #13

### DIFF
--- a/common/src/main/java/net/blay09/mods/kuma/api/KeyConflictContext.java
+++ b/common/src/main/java/net/blay09/mods/kuma/api/KeyConflictContext.java
@@ -1,5 +1,10 @@
 package net.blay09.mods.kuma.api;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.resources.Identifier;
+
+import java.util.Objects;
+
 /**
  * Represents the context in which a key conflict can occur.
  * <ul>
@@ -8,12 +13,64 @@ package net.blay09.mods.kuma.api;
  * <li><code>WORLD</code>: Key conflicts are limited to key mappings within world interaction.</li>
  * </ul>
  */
-public enum KeyConflictContext {
-    UNIVERSAL,
-    SCREEN,
-    WORLD;
+public class KeyConflictContext {
+
+    public static KeyConflictContext UNIVERSAL = new KeyConflictContext(Identifier.fromNamespaceAndPath("kuma", "universal")) {
+        @Override
+        public boolean conflictsWith(KeyConflictContext other) {
+            return true;
+        }
+    };
+
+    public static KeyConflictContext SCREEN = new KeyConflictContext(Identifier.fromNamespaceAndPath("kuma", "screen")) {
+        @Override
+        public boolean isActive() {
+            return Minecraft.getInstance().screen != null;
+        }
+    };
+    public static KeyConflictContext WORLD = new KeyConflictContext(Identifier.fromNamespaceAndPath("kuma", "world")) {
+        @Override
+        public boolean isActive() {
+            final var client = Minecraft.getInstance();
+            return client.screen == null && client.level != null;
+        }
+    };
+
+    private final Identifier identifier;
+
+    public KeyConflictContext(Identifier identifier) {
+        this.identifier = identifier;
+    }
 
     public boolean conflictsWith(KeyConflictContext other) {
-        return this == other || this == UNIVERSAL || other == UNIVERSAL;
+        return this == other;
     }
+
+    public boolean isActive() {
+        return true;
+    }
+
+    public Identifier identifier() {
+        return identifier;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (KeyConflictContext) obj;
+        return Objects.equals(this.identifier, that.identifier);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identifier);
+    }
+
+    @Override
+    public String toString() {
+        return "KeyConflictContext[" +
+                "identifier=" + identifier + ']';
+    }
+
 }

--- a/common/src/main/java/net/blay09/mods/kuma/api/Kuma.java
+++ b/common/src/main/java/net/blay09/mods/kuma/api/Kuma.java
@@ -35,12 +35,7 @@ public class Kuma {
      * @return True if the specified context is active, false otherwise.
      */
     public static boolean isContextActive(KeyConflictContext context) {
-        final var client = Minecraft.getInstance();
-        return switch (context) {
-            case SCREEN -> client.screen != null;
-            case WORLD -> client.screen == null && client.level != null;
-            default -> true;
-        };
+        return context.isActive();
     }
 
     /**


### PR DESCRIPTION
KeyConflictContext is no longer limited to three inbuilt ones, allowing for custom ones to be assigned to keys that may behave differently. I don't have an immediate use case for it but it at least makes it so Kuma isn't the limiting factor by being restricted to an enum here.