### PR TITLE
feat!: Add Kuma#wrap to make an existing KeyMapping managed #18

### DIFF
--- a/common/src/main/java/net/blay09/mods/kuma/AbstractManagedKeyMappingBuilder.java
+++ b/common/src/main/java/net/blay09/mods/kuma/AbstractManagedKeyMappingBuilder.java
@@ -1,20 +1,12 @@
 package net.blay09.mods.kuma;
 
 import net.blay09.mods.kuma.api.*;
-import net.minecraft.client.KeyMapping;
 import net.minecraft.resources.Identifier;
 import org.jspecify.annotations.Nullable;
 
-import java.util.function.Function;
-
-public abstract class AbstractManagedKeyMappingBuilder implements ManagedKeyMapping.Builder {
+public abstract class AbstractManagedKeyMappingBuilder<T> {
 
     protected final Identifier id;
-    protected KeyMapping.Category category;
-    @Nullable
-    protected String name;
-    @Nullable
-    protected KeyConflictContext context;
     protected InputBinding defaultBinding = InputBinding.none();
     @Nullable
     protected WorldInputEventHandler worldInputHandler;
@@ -23,80 +15,39 @@ public abstract class AbstractManagedKeyMappingBuilder implements ManagedKeyMapp
     protected boolean keyRepeat = false;
     protected boolean ignoresScreenFocus = false;
     protected KeyMappingStorage storage = Kuma.getDefaultStorage();
-    protected boolean skipRegistration = false;
 
-    public AbstractManagedKeyMappingBuilder(Identifier id) {
+    protected AbstractManagedKeyMappingBuilder(Identifier id) {
         this.id = id;
-        category = KumaKeyCategories.getDefaultCategory(id.getNamespace());
     }
 
-    @Override
-    public ManagedKeyMapping.Builder overrideName(String name) {
-        this.name = name;
-        return this;
-    }
+    protected abstract T self();
 
-    @Override
-    public ManagedKeyMapping.Builder overrideName(Function<Identifier, String> nameFunction) {
-        this.name = nameFunction.apply(id);
-        return this;
-    }
-
-    @Override
-    public ManagedKeyMapping.Builder overrideCategory(KeyMapping.Category category) {
-        this.category = category;
-        return this;
-    }
-
-    @Override
-    public ManagedKeyMapping.Builder withContext(KeyConflictContext context) {
-        this.context = context;
-        return this;
-    }
-
-    @Override
-    public ManagedKeyMapping.Builder withDefault(InputBinding binding) {
-        this.defaultBinding = binding;
-        return this;
-    }
-
-    @Override
-    public ManagedKeyMapping.Builder withCustomStorage(KeyMappingStorage storage) {
+    public T withCustomStorage(KeyMappingStorage storage) {
         this.storage = storage;
-        return this;
+        return self();
     }
 
-    @Override
-    public ManagedKeyMapping.Builder handleWorldInput(WorldInputEventHandler handler) {
+    public T handleWorldInput(WorldInputEventHandler handler) {
         this.worldInputHandler = handler;
-        return this;
+        return self();
     }
 
-    @Override
-    public ManagedKeyMapping.Builder handleScreenInput(ScreenInputEventHandler handler) {
+    public T handleScreenInput(ScreenInputEventHandler handler) {
         this.screenInputHandler = handler;
-        return this;
+        return self();
     }
 
-    @Override
-    public ManagedKeyMapping.Builder skipRegistration() {
-        skipRegistration = true;
-        return this;
-    }
-
-    @Override
-    public ManagedKeyMapping.Builder enableKeyRepeat() {
+    public T enableKeyRepeat() {
         keyRepeat = true;
-        return this;
+        return self();
     }
 
-    @Override
-    public ManagedKeyMapping.Builder ignoreScreenFocus() {
+    public T ignoreScreenFocus() {
         ignoresScreenFocus = true;
-        return this;
+        return self();
     }
 
-    private KeyConflictContext determineContext() {
+    protected KeyConflictContext determineContext() {
         if (worldInputHandler != null && screenInputHandler == null) {
             return KeyConflictContext.WORLD;
         }
@@ -105,24 +56,4 @@ public abstract class AbstractManagedKeyMappingBuilder implements ManagedKeyMapp
         }
         return KeyConflictContext.UNIVERSAL;
     }
-
-    @Override
-    public ManagedKeyMapping build() {
-        if (name == null) {
-            name = String.format("key.%s.%s", id.getNamespace(), id.getPath());
-        }
-        if (context == null) {
-            context = determineContext();
-        }
-        final var managedKeyMapping = skipRegistration ? createVirtualKeyMapping(id, context) : createVanillaKeyMapping(id, name, defaultBinding, context);
-        managedKeyMapping.getStorage().loadKeyMapping(managedKeyMapping);
-        ManagedKeyMappingRegistry.register(managedKeyMapping);
-        return managedKeyMapping;
-    }
-
-    protected ManagedKeyMapping createVirtualKeyMapping(Identifier id, KeyConflictContext context) {
-        return new ManagedVirtualKeyMapping(id, context, screenInputHandler, worldInputHandler, keyRepeat, ignoresScreenFocus, defaultBinding, storage);
-    }
-
-    protected abstract ManagedKeyMapping createVanillaKeyMapping(Identifier id, String name, InputBinding binding, KeyConflictContext context);
 }

--- a/common/src/main/java/net/blay09/mods/kuma/AbstractManagedKeyMappingRegistrationBuilder.java
+++ b/common/src/main/java/net/blay09/mods/kuma/AbstractManagedKeyMappingRegistrationBuilder.java
@@ -1,0 +1,84 @@
+package net.blay09.mods.kuma;
+
+import net.blay09.mods.kuma.api.*;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.resources.Identifier;
+import org.jspecify.annotations.Nullable;
+
+import java.util.function.Function;
+
+public abstract class AbstractManagedKeyMappingRegistrationBuilder extends AbstractManagedKeyMappingBuilder<ManagedKeyMapping.RegistrationBuilder> implements ManagedKeyMapping.RegistrationBuilder {
+
+    protected KeyMapping.Category category;
+    @Nullable
+    protected String name;
+    @Nullable
+    protected KeyConflictContext context;
+    protected boolean skipRegistration = false;
+
+    public AbstractManagedKeyMappingRegistrationBuilder(Identifier id) {
+        super(id);
+        category = KumaKeyCategories.getDefaultCategory(id.getNamespace());
+    }
+
+    @Override
+    protected ManagedKeyMapping.RegistrationBuilder self() {
+        return this;
+    }
+
+    @Override
+    public ManagedKeyMapping.RegistrationBuilder overrideName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Override
+    public ManagedKeyMapping.RegistrationBuilder overrideName(Function<Identifier, String> nameFunction) {
+        this.name = nameFunction.apply(id);
+        return this;
+    }
+
+    @Override
+    public ManagedKeyMapping.RegistrationBuilder overrideCategory(KeyMapping.Category category) {
+        this.category = category;
+        return this;
+    }
+
+    @Override
+    public ManagedKeyMapping.RegistrationBuilder withContext(KeyConflictContext context) {
+        this.context = context;
+        return this;
+    }
+
+    @Override
+    public ManagedKeyMapping.RegistrationBuilder withDefault(InputBinding binding) {
+        this.defaultBinding = binding;
+        return this;
+    }
+
+    @Override
+    public ManagedKeyMapping.RegistrationBuilder skipRegistration() {
+        skipRegistration = true;
+        return this;
+    }
+
+    @Override
+    public ManagedKeyMapping build() {
+        if (name == null) {
+            name = String.format("key.%s.%s", id.getNamespace(), id.getPath());
+        }
+        if (context == null) {
+            context = determineContext();
+        }
+        final var managedKeyMapping = skipRegistration ? createVirtualKeyMapping(id, context) : createVanillaKeyMapping(id, name, defaultBinding, context);
+        managedKeyMapping.getStorage().loadKeyMapping(managedKeyMapping);
+        ManagedKeyMappingRegistry.register(managedKeyMapping);
+        return managedKeyMapping;
+    }
+
+    protected ManagedKeyMapping createVirtualKeyMapping(Identifier id, KeyConflictContext context) {
+        return new ManagedVirtualKeyMapping(id, context, screenInputHandler, worldInputHandler, keyRepeat, ignoresScreenFocus, defaultBinding, storage);
+    }
+
+    protected abstract ManagedKeyMapping createVanillaKeyMapping(Identifier id, String name, InputBinding binding, KeyConflictContext context);
+}

--- a/common/src/main/java/net/blay09/mods/kuma/KumaRuntime.java
+++ b/common/src/main/java/net/blay09/mods/kuma/KumaRuntime.java
@@ -7,7 +7,9 @@ import net.minecraft.client.KeyMapping;
 import net.minecraft.resources.Identifier;
 
 public interface KumaRuntime {
-    ManagedKeyMapping.Builder createKeyMapping(Identifier id);
+    ManagedKeyMapping.RegistrationBuilder createKeyMapping(Identifier id);
+
+    ManagedKeyMapping.WrapperBuilder wrapKeyMapping(KeyMapping keyMapping);
 
     KeyModifiers getNativeKeyModifiers(KeyMapping keyMapping);
 

--- a/common/src/main/java/net/blay09/mods/kuma/ManagedWrappedKeyMapping.java
+++ b/common/src/main/java/net/blay09/mods/kuma/ManagedWrappedKeyMapping.java
@@ -1,0 +1,51 @@
+package net.blay09.mods.kuma;
+
+import net.blay09.mods.kuma.api.*;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.resources.Identifier;
+import org.jspecify.annotations.Nullable;
+
+public class ManagedWrappedKeyMapping extends AbstractManagedKeyMapping {
+
+    private final KeyMapping mapping;
+
+    public ManagedWrappedKeyMapping(Identifier id, KeyMapping mapping, KeyConflictContext context, @Nullable ScreenInputEventHandler screenInputEventHandler, @Nullable WorldInputEventHandler worldInputEventHandler, boolean keyRepeat, boolean ignoresScreenFocus, InputBinding defaultBinding, KeyMappingStorage storage) {
+        super(id, context, screenInputEventHandler, worldInputEventHandler, keyRepeat, ignoresScreenFocus, defaultBinding, storage);
+        this.mapping = mapping;
+    }
+
+    @Override
+    public void setBinding(InputBinding binding) {
+        mapping.setKey(binding.key());
+        if (mapping instanceof KumaKeyMapping kumaKeyMapping) {
+            kumaKeyMapping.kuma$setModifiers(binding.modifiers());
+            getStorage().saveKeyMapping(this);
+        }
+    }
+
+    @Override
+    public InputBinding getBinding() {
+        return InputBinding.of(mapping);
+    }
+
+    public KeyMapping wrap() {
+        if (mapping instanceof KumaKeyMapping kumaKeyMapping) {
+            kumaKeyMapping.kuma$setManagedKeyMapping(this);
+            kumaKeyMapping.kuma$setConflictContext(getContext());
+            kumaKeyMapping.kuma$setDefaultModifiers(getDefaultBinding().modifiers());
+            kumaKeyMapping.kuma$setModifiers(getDefaultBinding().modifiers());
+        }
+        return mapping;
+    }
+
+    @Override
+    public boolean isBound() {
+        return !mapping.isUnbound();
+    }
+
+    @Override
+    public boolean isUnbound() {
+        return mapping.isUnbound();
+    }
+
+}

--- a/common/src/main/java/net/blay09/mods/kuma/WrappedManagedKeyMappingBuilder.java
+++ b/common/src/main/java/net/blay09/mods/kuma/WrappedManagedKeyMappingBuilder.java
@@ -1,0 +1,68 @@
+package net.blay09.mods.kuma;
+
+import net.blay09.mods.kuma.api.InputBinding;
+import net.blay09.mods.kuma.api.KeyModifiers;
+import net.blay09.mods.kuma.api.KumaKeyMapping;
+import net.blay09.mods.kuma.api.ManagedKeyMapping;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.resources.Identifier;
+
+import java.util.Locale;
+
+public class WrappedManagedKeyMappingBuilder extends AbstractManagedKeyMappingBuilder<ManagedKeyMapping.WrapperBuilder> implements ManagedKeyMapping.WrapperBuilder {
+
+    private final KeyMapping keyMapping;
+
+    public WrappedManagedKeyMappingBuilder(KeyMapping keyMapping) {
+        super(deriveId(keyMapping));
+        if (keyMapping instanceof KumaKeyMapping kumaKeyMapping && kumaKeyMapping.kuma$isManaged()) {
+            throw new IllegalStateException("KeyMapping is already managed by Kuma");
+        }
+
+        this.keyMapping = keyMapping;
+        this.defaultBinding = InputBinding.of(keyMapping);
+    }
+
+    @Override
+    protected ManagedKeyMapping.WrapperBuilder self() {
+        return this;
+    }
+
+    private static Identifier deriveId(KeyMapping keyMapping) {
+        final var name = keyMapping.getName();
+        if (name.startsWith("key.")) {
+            final var suffix = name.substring("key.".length());
+            final var separatorIndex = suffix.indexOf('.');
+            if (separatorIndex >= 0) {
+                final var namespace = suffix.substring(0, separatorIndex);
+                final var path = suffix.substring(separatorIndex + 1);
+                if (Identifier.isValidNamespace(namespace) && Identifier.isValidPath(path)) {
+                    return Identifier.fromNamespaceAndPath(namespace, path);
+                }
+            } else if (Identifier.isValidPath(suffix)) {
+                return Identifier.fromNamespaceAndPath("minecraft", suffix);
+            }
+        }
+
+        return Identifier.fromNamespaceAndPath("kuma", sanitizeFallbackPath(name));
+    }
+
+    private static String sanitizeFallbackPath(String name) {
+        return name.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9_./-]", "_");
+    }
+
+    @Override
+    public ManagedKeyMapping.WrapperBuilder withDefaultModifiers(KeyModifiers modifiers) {
+        defaultBinding = new InputBinding(defaultBinding.key(), modifiers);
+        return this;
+    }
+
+    @Override
+    public ManagedKeyMapping build() {
+        final var managedKeyMapping = new ManagedWrappedKeyMapping(id, keyMapping, determineContext(), screenInputHandler, worldInputHandler, keyRepeat, ignoresScreenFocus, defaultBinding, storage);
+        managedKeyMapping.wrap();
+        managedKeyMapping.getStorage().loadKeyMapping(managedKeyMapping);
+        ManagedKeyMappingRegistry.register(managedKeyMapping);
+        return managedKeyMapping;
+    }
+}

--- a/common/src/main/java/net/blay09/mods/kuma/api/Kuma.java
+++ b/common/src/main/java/net/blay09/mods/kuma/api/Kuma.java
@@ -18,14 +18,26 @@ public class Kuma {
     private static final KumaRuntime runtime = KumaRuntimeSpi.create();
 
     /**
-     * Creates a new {@link ManagedKeyMapping.Builder} instance with a specified id.
+     * Creates a new {@link ManagedKeyMapping.RegistrationBuilder} instance with a specified id.
      * The returned builder can be used to configure and register a new key mapping.
      *
      * @param id The resource location that uniquely identifies the key mapping.
-     * @return A new {@link ManagedKeyMapping.Builder} instance.
+     * @return A new {@link ManagedKeyMapping.RegistrationBuilder} instance.
      */
-    public static ManagedKeyMapping.Builder createKeyMapping(Identifier id) {
+    public static ManagedKeyMapping.RegistrationBuilder createKeyMapping(Identifier id) {
         return runtime.createKeyMapping(id);
+    }
+
+    /**
+     * Creates a {@link ManagedKeyMapping.WrapperBuilder} for an existing {@link KeyMapping}.
+     * The returned builder uses the existing mapping's current key or mouse button as its default and
+     * allows customizing only wrapper-specific behavior such as handlers, storage, repeat, focus, and default modifiers.
+     *
+     * @param keyMapping the existing key mapping to wrap
+     * @return a builder that will turn the supplied key mapping into a Kuma-managed mapping on {@code build()}
+     */
+    public static ManagedKeyMapping.WrapperBuilder wrap(KeyMapping keyMapping) {
+        return runtime.wrapKeyMapping(keyMapping);
     }
 
     /**

--- a/common/src/main/java/net/blay09/mods/kuma/api/ManagedKeyMapping.java
+++ b/common/src/main/java/net/blay09/mods/kuma/api/ManagedKeyMapping.java
@@ -210,41 +210,7 @@ public interface ManagedKeyMapping {
 
     KeyMappingStorage getStorage();
 
-    /**
-     * A builder interface for creating instances of {@link ManagedKeyMapping}.
-     * This builder allows configuring various properties of the key mapping, such as the input binding, event handlers, and conflict context.
-     * You can obtain an instance of this builder by calling {@link Kuma#createKeyMapping(net.minecraft.resources.Identifier id)}.
-     */
-    interface Builder {
-        Builder overrideName(String name);
-
-        Builder overrideName(Function<Identifier, String> nameFunction);
-
-        /**
-         * Sets the category for this key mapping. The category is used to group related key mappings together in the controls menu.
-         * By default, the category is set to <code>key.categories.[namespace].default</code> where <code>[namespace]</code> is the namespace of the key mapping's id
-         *
-         * @param category The category for this key mapping.
-         * @return This builder instance, for chaining.
-         */
-        Builder overrideCategory(KeyMapping.Category category);
-
-        /**
-         * Sets the key conflict context for this key mapping. The conflict context is used to determine what other key mappings can be considered conflicting.
-         *
-         * @param context The key conflict context for this key mapping.
-         * @return This builder instance, for chaining.
-         */
-        Builder withContext(KeyConflictContext context);
-
-        /**
-         * Sets the default input binding for this key mapping.
-         *
-         * @param binding The default input binding to use for this key mapping.
-         * @return This builder instance, for chaining.
-         */
-        Builder withDefault(InputBinding binding);
-
+    interface Builder<T extends Builder<T>> {
         /**
          * Specify a custom storage provider for storing this key's modifiers and extra data.
          * Omit this call to use the default storage provided by Kuma.
@@ -252,7 +218,7 @@ public interface ManagedKeyMapping {
          * @param storage The storage provider to use for this key mapping.
          * @return This builder instance, for chaining.
          */
-        Builder withCustomStorage(KeyMappingStorage storage);
+        T withCustomStorage(KeyMappingStorage storage);
 
         /**
          * Adds a handler for world input events that are associated with this managed key mapping.
@@ -261,14 +227,7 @@ public interface ManagedKeyMapping {
          * @param handler The handler to be called for world input events.
          * @return This builder instance, for chaining.
          */
-        Builder handleWorldInput(WorldInputEventHandler handler);
-
-        /**
-         * Skips registration of this key mapping. This can be used for virtual key mappings that should not show up in the Controls menu.
-         *
-         * @return This builder instance, for chaining.
-         */
-        Builder skipRegistration();
+        T handleWorldInput(WorldInputEventHandler handler);
 
         /**
          * Adds a handler for screen input events that are associated with this managed key mapping.
@@ -277,7 +236,7 @@ public interface ManagedKeyMapping {
          * @param handler The handler to be called for screen input events.
          * @return This builder instance, for chaining.
          */
-        Builder handleScreenInput(ScreenInputEventHandler handler);
+        T handleScreenInput(ScreenInputEventHandler handler);
 
         /**
          * By default, screen handlers are not fired if a widget on a screen has focus (e.g. a text field).
@@ -285,7 +244,14 @@ public interface ManagedKeyMapping {
          *
          * @return This builder instance, for chaining.
          */
-        Builder ignoreScreenFocus();
+        T ignoreScreenFocus();
+
+        /**
+         * Enabling key repeat will cause handle*Input() handlers to be called repeatedly if the key is held down.
+         *
+         * @return This builder instance, for chaining.
+         */
+        T enableKeyRepeat();
 
         /**
          * Builds and returns the configured ManagedKeyMapping instance.
@@ -293,13 +259,63 @@ public interface ManagedKeyMapping {
          * @return The built ManagedKeyMapping instance.
          */
         ManagedKeyMapping build();
+    }
+
+    /**
+     * A builder interface for creating instances of {@link ManagedKeyMapping}.
+     * This builder allows configuring various properties of the key mapping, such as the input binding, event handlers, and conflict context.
+     * You can obtain an instance of this builder by calling {@link Kuma#createKeyMapping(net.minecraft.resources.Identifier id)}.
+     */
+    interface RegistrationBuilder extends Builder<RegistrationBuilder> {
+        RegistrationBuilder overrideName(String name);
+
+        RegistrationBuilder overrideName(Function<Identifier, String> nameFunction);
 
         /**
-         * Enabling key repeat will cause handle*Input() handlers to be called repeatedly if the key is held down.
+         * Sets the category for this key mapping. The category is used to group related key mappings together in the controls menu.
+         * By default, the category is set to <code>key.categories.[namespace].default</code> where <code>[namespace]</code> is the namespace of the key mapping's id
+         *
+         * @param category The category for this key mapping.
+         * @return This builder instance, for chaining.
+         */
+        RegistrationBuilder overrideCategory(KeyMapping.Category category);
+
+        /**
+         * Sets the key conflict context for this key mapping. The conflict context is used to determine what other key mappings can be considered conflicting.
+         *
+         * @param context The key conflict context for this key mapping.
+         * @return This builder instance, for chaining.
+         */
+        RegistrationBuilder withContext(KeyConflictContext context);
+
+        /**
+         * Sets the default input binding for this key mapping.
+         *
+         * @param binding The default input binding to use for this key mapping.
+         * @return This builder instance, for chaining.
+         */
+        RegistrationBuilder withDefault(InputBinding binding);
+
+        /**
+         * Skips registration of this key mapping. This can be used for virtual key mappings that should not show up in the Controls menu.
          *
          * @return This builder instance, for chaining.
          */
-        Builder enableKeyRepeat();
+        RegistrationBuilder skipRegistration();
+    }
+
+    /**
+     * A builder interface for wrapping existing {@link KeyMapping} instances with Kuma management.
+     * You can obtain an instance of this builder by calling {@link Kuma#wrap(KeyMapping)}.
+     */
+    interface WrapperBuilder extends Builder<WrapperBuilder> {
+        /**
+         * Sets the default modifiers for the wrapped key mapping while keeping its existing key or mouse button.
+         *
+         * @param modifiers The default modifiers to use for the wrapped key mapping.
+         * @return This builder instance, for chaining.
+         */
+        WrapperBuilder withDefaultModifiers(KeyModifiers modifiers);
     }
 
 }

--- a/fabric-example/src/main/java/net/blay09/mods/kuma/fabric/FabricKumaExample.java
+++ b/fabric-example/src/main/java/net/blay09/mods/kuma/fabric/FabricKumaExample.java
@@ -6,6 +6,8 @@ import net.blay09.mods.kuma.api.KeyModifier;
 import net.blay09.mods.kuma.api.KeyModifiers;
 import net.blay09.mods.kuma.api.Kuma;
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
+import net.minecraft.client.Minecraft;
 import net.minecraft.resources.Identifier;
 
 public class FabricKumaExample implements ClientModInitializer {
@@ -40,5 +42,10 @@ public class FabricKumaExample implements ClientModInitializer {
                     return true;
                 })
                 .build();
+
+        ClientLifecycleEvents.CLIENT_STARTED.register(client -> {
+            final var managedSwapOffHand = Kuma.wrap(client.options.keySwapOffhand).build();
+            managedSwapOffHand.setBinding(InputBinding.key(InputConstants.KEY_F, KeyModifiers.of(KeyModifier.CONTROL)));
+        });
     }
 }

--- a/fabric/src/main/java/net/blay09/mods/kuma/fabric/FabricKumaRuntime.java
+++ b/fabric/src/main/java/net/blay09/mods/kuma/fabric/FabricKumaRuntime.java
@@ -1,6 +1,7 @@
 package net.blay09.mods.kuma.fabric;
 
 import net.blay09.mods.kuma.KumaRuntime;
+import net.blay09.mods.kuma.WrappedManagedKeyMappingBuilder;
 import net.blay09.mods.kuma.api.KeyMappingStorage;
 import net.blay09.mods.kuma.api.KeyModifiers;
 import net.blay09.mods.kuma.api.ManagedKeyMapping;
@@ -18,8 +19,13 @@ public class FabricKumaRuntime implements KumaRuntime {
     private KeyMappingStorage defaultStorage;
 
     @Override
-    public ManagedKeyMapping.Builder createKeyMapping(Identifier id) {
-        return new FabricManagedKeyMappingBuilder(id);
+    public ManagedKeyMapping.RegistrationBuilder createKeyMapping(Identifier id) {
+        return new FabricManagedKeyMappingRegistrationBuilder(id);
+    }
+
+    @Override
+    public ManagedKeyMapping.WrapperBuilder wrapKeyMapping(KeyMapping keyMapping) {
+        return new WrappedManagedKeyMappingBuilder(keyMapping);
     }
 
     @Override

--- a/fabric/src/main/java/net/blay09/mods/kuma/fabric/FabricManagedKeyMappingRegistrationBuilder.java
+++ b/fabric/src/main/java/net/blay09/mods/kuma/fabric/FabricManagedKeyMappingRegistrationBuilder.java
@@ -1,15 +1,15 @@
 package net.blay09.mods.kuma.fabric;
 
-import net.blay09.mods.kuma.AbstractManagedKeyMappingBuilder;
+import net.blay09.mods.kuma.AbstractManagedKeyMappingRegistrationBuilder;
 import net.blay09.mods.kuma.ManagedVanillaKeyMapping;
 import net.blay09.mods.kuma.api.*;
 import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.resources.Identifier;
 
-public class FabricManagedKeyMappingBuilder extends AbstractManagedKeyMappingBuilder {
+public class FabricManagedKeyMappingRegistrationBuilder extends AbstractManagedKeyMappingRegistrationBuilder {
 
-    public FabricManagedKeyMappingBuilder(Identifier id) {
+    public FabricManagedKeyMappingRegistrationBuilder(Identifier id) {
         super(id);
     }
 

--- a/forge/src/main/java/net/blay09/mods/kuma/forge/ForgeKumaRuntime.java
+++ b/forge/src/main/java/net/blay09/mods/kuma/forge/ForgeKumaRuntime.java
@@ -1,6 +1,7 @@
 package net.blay09.mods.kuma.forge;
 
 import net.blay09.mods.kuma.KumaRuntime;
+import net.blay09.mods.kuma.WrappedManagedKeyMappingBuilder;
 import net.blay09.mods.kuma.api.KeyMappingStorage;
 import net.blay09.mods.kuma.api.KeyModifiers;
 import net.blay09.mods.kuma.api.ManagedKeyMapping;
@@ -20,6 +21,11 @@ public class ForgeKumaRuntime implements KumaRuntime {
     @Override
     public ManagedKeyMapping.Builder createKeyMapping(Identifier id) {
         return new ForgeManagedKeyMappingBuilder(id);
+    }
+
+    @Override
+    public ManagedKeyMapping.WrapperBuilder wrapKeyMapping(KeyMapping keyMapping) {
+        return new WrappedManagedKeyMappingBuilder(keyMapping);
     }
 
     @Override

--- a/neoforge/src/main/java/net/blay09/mods/kuma/neoforge/NeoForgeKumaRuntime.java
+++ b/neoforge/src/main/java/net/blay09/mods/kuma/neoforge/NeoForgeKumaRuntime.java
@@ -1,6 +1,7 @@
 package net.blay09.mods.kuma.neoforge;
 
 import net.blay09.mods.kuma.KumaRuntime;
+import net.blay09.mods.kuma.WrappedManagedKeyMappingBuilder;
 import net.blay09.mods.kuma.api.KeyMappingStorage;
 import net.blay09.mods.kuma.api.KeyModifiers;
 import net.blay09.mods.kuma.api.ManagedKeyMapping;
@@ -19,8 +20,13 @@ public class NeoForgeKumaRuntime implements KumaRuntime {
     private KeyMappingStorage defaultStorage;
 
     @Override
-    public ManagedKeyMapping.Builder createKeyMapping(Identifier id) {
-        return new NeoForgeManagedKeyMappingBuilder(id);
+    public ManagedKeyMapping.RegistrationBuilder createKeyMapping(Identifier id) {
+        return new NeoForgeManagedKeyMappingRegistrationBuilder(id);
+    }
+
+    @Override
+    public ManagedKeyMapping.WrapperBuilder wrapKeyMapping(KeyMapping keyMapping) {
+        return new WrappedManagedKeyMappingBuilder(keyMapping);
     }
 
     @Override

--- a/neoforge/src/main/java/net/blay09/mods/kuma/neoforge/NeoForgeManagedKeyMappingRegistrationBuilder.java
+++ b/neoforge/src/main/java/net/blay09/mods/kuma/neoforge/NeoForgeManagedKeyMappingRegistrationBuilder.java
@@ -1,6 +1,6 @@
 package net.blay09.mods.kuma.neoforge;
 
-import net.blay09.mods.kuma.AbstractManagedKeyMappingBuilder;
+import net.blay09.mods.kuma.AbstractManagedKeyMappingRegistrationBuilder;
 import net.blay09.mods.kuma.ManagedVanillaKeyMapping;
 import net.blay09.mods.kuma.api.InputBinding;
 import net.blay09.mods.kuma.api.KeyConflictContext;
@@ -8,9 +8,9 @@ import net.blay09.mods.kuma.api.ManagedKeyMapping;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.resources.Identifier;
 
-public class NeoForgeManagedKeyMappingBuilder extends AbstractManagedKeyMappingBuilder {
+public class NeoForgeManagedKeyMappingRegistrationBuilder extends AbstractManagedKeyMappingRegistrationBuilder {
 
-    public NeoForgeManagedKeyMappingBuilder(Identifier id) {
+    public NeoForgeManagedKeyMappingRegistrationBuilder(Identifier id) {
         super(id);
     }
 


### PR DESCRIPTION
Example mod turns Vanilla's Swap Off Hand into a managed key mapping, allowing modifiers to be used on it.

26.1+ only because `ManagedKeyMapping.Builder` became `ManagedKeyMapping.RegistrationBuilder`.